### PR TITLE
Ckan 2.6.8 datapusher reverse proxy

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -32,6 +32,17 @@ MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760
 CHUNK_SIZE = 16 * 1024 # 16kb
 DOWNLOAD_TIMEOUT = 30
 
+### ASLBAT ###
+# See also ckan/ckanext/datapusher/logic/action.py
+#
+# LOGGING NOTE:
+# For logging the level is over info. Use logging.error to print message to standard output.
+# Do not use logger in the push_to_datastore function, it logs message to
+# ckan. Use logging.....
+#
+# SSL_VERIFY NOTE:
+# Here this variable does not work, it overlaps with ckan global variable
+# To disable SSL_VERIFY set SSL_VERIFY = False also in the else
 if web.app.config.get('SSL_VERIFY') in ['False', 'FALSE', '0', False, 0]:
     SSL_VERIFY = False
 else:

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -345,7 +345,8 @@ def push_to_datastore(task_id, input, dry_run=False):
     
     # replace original_url_base with callback_url_base
     logging.debug("----------CKAN URL------BEFORE: %s" % ckan_url)
-    ckan_url = replace_original_url_base_with_callback_url_base(ckan_url, original_url_base, callback_url_base)
+    if original_url_base:
+        ckan_url = replace_original_url_base_with_callback_url_base(ckan_url, original_url_base, callback_url_base)
     logging.debug("----------CKAN URL------AFTER*: %s" % ckan_url)
     ### ASLBAT ###
     
@@ -367,7 +368,8 @@ def push_to_datastore(task_id, input, dry_run=False):
     ### ASLBAT ###
     # replace original_url_base with callback_url_base
     logging.debug("----------*****URL------BEFORE: %s" % url)
-    url = replace_original_url_base_with_callback_url_base(url, original_url_base, callback_url_base)
+    if original_url_base:
+        url = replace_original_url_base_with_callback_url_base(url, original_url_base, callback_url_base)
     logging.debug("----------*****URL------AFTER*: %s" % url)
     ### ASLBAT ###
 


### PR DESCRIPTION
This change get two additional values from ckan when pushing to datastore:

- original_url_base
- callback_url_base

This is done to manage different urls of ckan if behind reverse proxy. Datapusher then replaces the ckan external base url with the callback base url. See same pull request on repository italia/ckan. This change is based on the version referenced by the italia/ckan-it repository. See italia/ckan#7 pull request.